### PR TITLE
Feature/add listen commands function

### DIFF
--- a/mode/device.py
+++ b/mode/device.py
@@ -7,17 +7,14 @@ import websocket
 import threading
 
 class Device:
-
+	
 	def __init__(self):
 		self.host              = 'api.tinkermode.com'
 		self.port              = 443
 		self.devicId           = ''
 		self.token             = ''
-		self.on_open           = default_on_open
-		self.on_message        = default_on_message
-		self.on_error          = default_on_error
-		self.on_close          = default_on_close
 		self.websocket_debug   = False
+		self.wait              = 0.5
 
 	def set_api_host(self, host):
 		self.host = host
@@ -34,7 +31,7 @@ class Device:
 				 json.dumps({"eventType":eventType, "eventData":eventData}), \
 			         headers={'Content-Type':'application/json','Authorization':'ModeCloud ' + self.token})
 		print(r)	
-
+	
 	def listen_commands(self):
 		websocket.enableTrace(self.websocket_debug)
 		ws = websocket.WebSocketApp('wss://' + self.host + '/devices/' + str(self.deviceId) + '/command',
@@ -47,43 +44,40 @@ class Device:
 		# Ctrl+C to close websocket
 		except KeyboardInterrupt:
 			ws.close()
-
-# websocket callback
-wait = 0.5 #sec
-
-# when open websocke
-def default_on_open(ws):
-	global wait
-	wait = 0.5
-	print('connected')
-
-# when get message
-def default_on_message(ws, message):
-	print(message)
-
-# when error
-def default_on_error(ws, error):
-	print("error")
-	global wait
-	if wait < 60:
-		wait *= 2 # first error => wait for 1sec.
-	__try_reconnect(ws)
-
-# when close websocket
-def default_on_close(ws):
-	print('disconnected')
-
-def __try_reconnect(ws):
-	print('wait for', wait, 'sec to reconnect')
-	t = threading.Timer(wait, __reconnect, args=[ws])
-	t.start();
-
-def __reconnect(ws):
-	print('reconnecting ..')
 	
-	#Start websocket
-	try:
-		ws.run_forever()
-	# Ctrl+C to close websocket
-	except KeyboardInterrupt:
-		ws.close()
+	# websocket callback methods
+	# when open websocke
+	def on_open(self, ws):
+		self.wait = 0.5
+		print('connected')
+
+	# when get message
+	def on_message(ws, message):
+		print(message)
+
+	# when error
+	def on_error(self, ws, error):
+		print("error")
+		if self.wait < 60:
+			self.wait *= 2 # first error => wait for 1sec.
+		print(self.wait)
+		self._try_reconnect(ws)
+	
+	# when close websocket
+	def on_close(self, ws):
+		print('disconnected')
+
+	def _try_reconnect(self, ws):
+		print('wait for', self.wait, 'sec to reconnect')
+		t = threading.Timer(self.wait, self._reconnect, args=[ws])
+		t.start();
+
+	def _reconnect(self, ws):
+		print('reconnecting ..')
+		
+		#start websocket
+		try:
+			ws.run_forever()
+		# Ctrl+C to close websocket
+		except KeyboardInterrupt:
+			ws.close()

--- a/mode/device.py
+++ b/mode/device.py
@@ -4,19 +4,20 @@
 import requests
 import json
 import websocket
-
+import threading
 
 class Device:
 
 	def __init__(self):
-		self.host = 'api.tinkermode.com'
-		self.port = 443
-		self.devicId = ''
-		self.token = ''
-		self.on_open = default_on_open
-		self.on_message = default_on_message
-		self.on_error = default_on_error
-		self.on_close = default_on_close
+		self.host              = 'api.tinkermode.com'
+		self.port              = 443
+		self.devicId           = ''
+		self.token             = ''
+		self.on_open           = default_on_open
+		self.on_message        = default_on_message
+		self.on_error          = default_on_error
+		self.on_close          = default_on_close
+		self.websocket_debug   = False
 
 	def set_api_host(self, host):
 		self.host = host
@@ -25,6 +26,9 @@ class Device:
 		self.deviceId = deviceId
 		self.token = token
 
+	def websocket_trace(self, b):
+		self.websocket_debug = b
+
 	def trigger_event(self, eventType, eventData):
 		r = requests.put('https://' + self.host + '/devices/' + str(self.deviceId) + '/event', \
 				 json.dumps({"eventType":eventType, "eventData":eventData}), \
@@ -32,7 +36,7 @@ class Device:
 		print(r)	
 
 	def listen_commands(self):
-		websocket.enableTrace(True)
+		websocket.enableTrace(self.websocket_debug)
 		ws = websocket.WebSocketApp('wss://' + self.host + '/devices/' + str(self.deviceId) + '/command',
 					    header=["Authorization: ModeCloud %s" % self.token], on_open=self.on_open, \
 					    on_message=self.on_message, on_error=self.on_error, on_close=self.on_close)
@@ -45,8 +49,12 @@ class Device:
 			ws.close()
 
 # websocket callback
-# when open websocket
+wait = 0.5 #sec
+
+# when open websocke
 def default_on_open(ws):
+	global wait
+	wait = 0.5
 	print('connected')
 
 # when get message
@@ -56,7 +64,26 @@ def default_on_message(ws, message):
 # when error
 def default_on_error(ws, error):
 	print("error")
-	
+	global wait
+	if wait < 60:
+		wait *= 2 # first error => wait for 1sec.
+	__try_reconnect(ws)
+
 # when close websocket
 def default_on_close(ws):
 	print('disconnected')
+
+def __try_reconnect(ws):
+	print('wait for', wait, 'sec to reconnect')
+	t = threading.Timer(wait, __reconnect, args=[ws])
+	t.start();
+
+def __reconnect(ws):
+	print('reconnecting ..')
+	
+	#Start websocket
+	try:
+		ws.run_forever()
+	# Ctrl+C to close websocket
+	except KeyboardInterrupt:
+		ws.close()

--- a/mode/device.py
+++ b/mode/device.py
@@ -23,6 +23,3 @@ class Device:
 				 json.dumps({"eventType":eventType, "eventData":eventData}), \
 			         headers={'Content-Type':'application/json','Authorization':'ModeCloud ' + self.token})
 		print(r)	 
- 
-def foo():
-	print('foo')

--- a/mode/device.py
+++ b/mode/device.py
@@ -3,14 +3,21 @@
 
 import requests
 import json
+import websocket
+
 
 class Device:
+
 	def __init__(self):
 		self.host = 'api.tinkermode.com'
 		self.port = 443
 		self.devicId = ''
 		self.token = ''
-		
+		self.on_open = default_on_open
+		self.on_message = default_on_message
+		self.on_error = default_on_error
+		self.on_close = default_on_close
+
 	def set_api_host(self, host):
 		self.host = host
 	
@@ -22,4 +29,34 @@ class Device:
 		r = requests.put('https://' + self.host + '/devices/' + str(self.deviceId) + '/event', \
 				 json.dumps({"eventType":eventType, "eventData":eventData}), \
 			         headers={'Content-Type':'application/json','Authorization':'ModeCloud ' + self.token})
-		print(r)	 
+		print(r)	
+
+	def listen_commands(self):
+		websocket.enableTrace(True)
+		ws = websocket.WebSocketApp('wss://' + self.host + '/devices/' + str(self.deviceId) + '/command',
+					    header=["Authorization: ModeCloud %s" % self.token], on_open=self.on_open, \
+					    on_message=self.on_message, on_error=self.on_error, on_close=self.on_close)
+
+		# Start websocket
+		try:
+			ws.run_forever()
+		# Ctrl+C to close websocket
+		except KeyboardInterrupt:
+			ws.close()
+
+# websocket callback
+# when open websocket
+def default_on_open(ws):
+	print('connected')
+
+# when get message
+def default_on_message(ws, message):
+	print(message)
+
+# when error
+def default_on_error(ws, error):
+	print("error")
+	
+# when close websocket
+def default_on_close(ws):
+	print('disconnected')

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,8 @@ from setuptools import setup, find_packages
 from mode import __author__, __version__, __license__
 
 requirements = [
-    'requests >= 2.5.2, != 2.11.0, != 2.12.2'
+    'requests >= 2.5.2, != 2.11.0, != 2.12.2',
+    'websocket-client >= 0.40.0'
 ]
  
 setup(

--- a/test.py
+++ b/test.py
@@ -11,7 +11,7 @@ API_KEY = 'v1.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
 mode_device.set_device_keys(DEVICE_ID, API_KEY)
 mode_device.set_api_host('iot-device.jp-east-1.api.cloud.nifty.com')
 
-mode_device.trigger_event('mode-py_test', {'value':'hoge'})
+#mode_device.trigger_event('mode-py_test', {'value':'hoge'})
 
 mode_device.on_message = test_func
 mode_device.listen_commands()

--- a/test.py
+++ b/test.py
@@ -1,8 +1,9 @@
 from mode import device
 
+def test_func(ws, message):
+	print(message + ' in test.py')
+
 mode_device = device.Device()
-#m.setApiHost("example.com")
-#print(m.host)
 
 DEVICE_ID = 1
 API_KEY = 'v1.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
@@ -10,4 +11,7 @@ API_KEY = 'v1.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
 mode_device.set_device_keys(DEVICE_ID, API_KEY)
 mode_device.set_api_host('iot-device.jp-east-1.api.cloud.nifty.com')
 
-mode_device.trigger_event('mode-py_test', {'value':'banana'})
+mode_device.trigger_event('mode-py_test', {'value':'hoge'})
+
+mode_device.on_message = test_func
+mode_device.listen_commands()


### PR DESCRIPTION
## sammary
websocket接続を確立し、コマンドを受信するためのメソッド listen_commandsメソッドをdeviceクラスに追加。

(3/14) add try_reconnect() function. It try to reconnect when error.

## tests
`$ git clone -b feature/add_listen_commands_function https://github.com/pachicourse/mode-py.git`

必要なパッケージが入っていなければインストール
`$ pip3 install requests`
`$ pip3 install websocket-client`

test.py内のDEVICE_IDやAPI_KEYを自身のものに書き換える。
`$ vi test.py`

実行
`$ python3 test.py`

待機状態になるのでIoTデバイスハブのアプリシミュレーターからコマンドを送信。

`$ '送られてきたコマンド' in test.py`

と出力されれば成功。

### (3/14) reconnection test.

1.On ubuntu server, rewrite this file to set ufw rule.
`$ vim /etc/default/ufw`

Write `DEFAULT_OUTPUT_POLICY="DROP"` to file.

2.Reload ufw
`$ ufw reload`

3.Run `test.py`
`$ python3 test.py`

4.Rewrite /etc/default/ufw again
 `$ vim /etc/default/ufw`
Write `DEFAULT_OUTPUT_POLICY="ACCEPT"` to file.

5.test.py will connect to Device hub collectry and output to console.
`connected`